### PR TITLE
Change furthest episode logic

### DIFF
--- a/src/components/GlobalContext.ts
+++ b/src/components/GlobalContext.ts
@@ -4,14 +4,14 @@ export interface GlobalContextProps {
   initialRender: boolean
   furthestEpisode: number
   setInitialRender: React.Dispatch<React.SetStateAction<boolean>>
-  setFurthestEpisode: React.Dispatch<React.SetStateAction<number>>
+  setEpisodeAsFurthest: (x: number) => void
 }
 
 export const globalContextDefault: GlobalContextProps = {
   initialRender: true,
   furthestEpisode: 0,
   setInitialRender: () => {},
-  setFurthestEpisode: () => {}
+  setEpisodeAsFurthest: (_: number) => {}
 }
 
 export default React.createContext<GlobalContextProps>(globalContextDefault)

--- a/src/components/GlobalContextSetter.tsx
+++ b/src/components/GlobalContextSetter.tsx
@@ -10,17 +10,12 @@ const GlobalContextSetter = ({
   episodeNumber,
   children
 }: GlobalContextProviderProps) => {
-  const { setFurthestEpisode } = useContext(GlobalContext)
+  const { initialRender, setEpisodeAsFurthest } = useContext(GlobalContext)
   useEffect(() => {
-    // https://overreacted.io/a-complete-guide-to-useeffect/#making-effects-self-sufficient
-    setFurthestEpisode(prevFurthestEpisode => {
-      if (prevFurthestEpisode < episodeNumber) {
-        return episodeNumber
-      } else {
-        return prevFurthestEpisode
-      }
-    })
-  }, [episodeNumber, setFurthestEpisode])
+    if (initialRender) {
+      setEpisodeAsFurthest(episodeNumber)
+    }
+  }, [episodeNumber, initialRender, setEpisodeAsFurthest])
   return <React.Fragment>{children}</React.Fragment>
 }
 

--- a/src/components/GlobalState.tsx
+++ b/src/components/GlobalState.tsx
@@ -31,7 +31,15 @@ const GlobalState = ({ children }: { children: React.ReactNode }) => {
         initialRender,
         setInitialRender,
         furthestEpisode,
-        setFurthestEpisode
+        setEpisodeAsFurthest: (episodeNumber: number) => {
+          setFurthestEpisode((prevFurthestEpisode: number) => {
+            if (prevFurthestEpisode < episodeNumber) {
+              return episodeNumber
+            } else {
+              return prevFurthestEpisode
+            }
+          })
+        }
       }}
     >
       {children}

--- a/src/components/GlobalState.tsx
+++ b/src/components/GlobalState.tsx
@@ -17,11 +17,11 @@ const GlobalState = ({ children }: { children: React.ReactNode }) => {
       setInitialRender(false)
     }
     if (router) {
-      router.events.on('routeChangeComplete', handleRouteChange)
+      router.events.on('routeChangeStart', handleRouteChange)
     }
     return () => {
       if (router) {
-        router.events.off('routeChangeComplete', handleRouteChange)
+        router.events.off('routeChangeStart', handleRouteChange)
       }
     }
   }, [router])

--- a/src/components/NextLessonButton.tsx
+++ b/src/components/NextLessonButton.tsx
@@ -8,10 +8,12 @@ import locale from 'src/lib/locale'
 import { colors, fontSizes, lineHeights, radii, spaces } from 'src/lib/theme'
 import { Strong } from 'src/components/ContentTags'
 import EpisodeContext from 'src/components/EpisodeContext'
+import GlobalContext from 'src/components/GlobalContext'
 import Emoji from 'src/components/Emoji'
 
 const NextLessonButton = ({ halfMargin }: { halfMargin?: boolean }) => {
   const { episodeNumber } = useContext(EpisodeContext)
+  const { setEpisodeAsFurthest } = useContext(GlobalContext)
   const nextEpisodeNumber = episodeNumber + 1
 
   return (
@@ -24,6 +26,9 @@ const NextLessonButton = ({ halfMargin }: { halfMargin?: boolean }) => {
     >
       <Link href={`/${nextEpisodeNumber}`} passHref>
         <a
+          onClick={() => {
+            setEpisodeAsFurthest(episodeNumber)
+          }}
           css={css`
             display: inline-block;
             padding: ${locale === 'jp' ? spaces(0.25) : spaces(0.5)}

--- a/src/components/NextLessonButton.tsx
+++ b/src/components/NextLessonButton.tsx
@@ -27,7 +27,7 @@ const NextLessonButton = ({ halfMargin }: { halfMargin?: boolean }) => {
       <Link href={`/${nextEpisodeNumber}`} passHref>
         <a
           onClick={() => {
-            setEpisodeAsFurthest(episodeNumber)
+            setEpisodeAsFurthest(nextEpisodeNumber)
           }}
           css={css`
             display: inline-block;


### PR DESCRIPTION
- Only make the next lesson button to update the furthest page read, except the initial page load
- Must use `routeChangeStart` instead, otherwise `initialRender` will be updated after the child components already rendered